### PR TITLE
Corrected Typo Error And Added New Relationship for Process data source object

### DIFF
--- a/Aggregating_Option/process.yml
+++ b/Aggregating_Option/process.yml
@@ -5,6 +5,7 @@ data_components:
   relationships:
   - {relationship: created, source_data_element: user, target_data_element: process}
   - {relationship: created, source_data_element: process, target_data_element: process}
+  - {relationship: created, source_data_element: process, target_data_element: thread}
   type: activity
 - name: process modification
   relationships:

--- a/Aggregating_Option/windows_registry.yml
+++ b/Aggregating_Option/windows_registry.yml
@@ -3,9 +3,9 @@ contributors: [ATT&CK]
 data_components:
 - name: windows registry key creation
   relationships:
-  - {relationship: creted, source_data_element: process, target_data_element: windows
+  - {relationship: created, source_data_element: process, target_data_element: windows
       registry key}
-  - {relationship: creted, source_data_element: process, target_data_element: windows
+  - {relationship: created, source_data_element: process, target_data_element: windows
       registry key value}
   type: activity
 - name: windows registry key deletion

--- a/Expanding_Option/attack_data_sources.yaml
+++ b/Expanding_Option/attack_data_sources.yaml
@@ -200,10 +200,10 @@
       type: activity
       relationships:
         - source_data_element: process
-          relationship: creted
+          relationship: created
           target_data_element: windows registry key
         - source_data_element: process
-          relationship: creted
+          relationship: created
           target_data_element: windows registry key value
     - name: windows registry key deletion
       type: activity
@@ -278,6 +278,9 @@
         - source_data_element: process
           relationship: created
           target_data_element: process
+        - source_data_element: process
+          relationship: created
+          target_data_element: thread
     - name: process modification
       type: activity
       relationships:

--- a/attack_data_sources.yaml
+++ b/attack_data_sources.yaml
@@ -209,10 +209,10 @@
       type: activity
       relationships:
         - source_data_element: process
-          relationship: creted
+          relationship: created
           target_data_element: windows registry key
         - source_data_element: process
-          relationship: creted
+          relationship: created
           target_data_element: windows registry key value
     - name: windows registry key deletion
       type: activity
@@ -287,6 +287,9 @@
         - source_data_element: process
           relationship: created
           target_data_element: process
+        - source_data_element: process
+          relationship: created
+          target_data_element: thread
     - name: process modification
       type: activity
       relationships:


### PR DESCRIPTION
- Typo error in Windows Registry data source object: Created instead of Created
- New relationship in Process data source object: Process created Thread