### PR TITLE
The casing for macOS is not in line with CTI STIX

### DIFF
--- a/contribution/application_log.yml
+++ b/contribution/application_log.yml
@@ -6,7 +6,7 @@ collection_layers:
 platforms:
   - Windows
   - Linux
-  - MacOS
+  - macOS
   - IaaS
   - SaaS
   - Office 365

--- a/contribution/drive.yml
+++ b/contribution/drive.yml
@@ -5,7 +5,7 @@ collection_layers:
 platforms:
   - Windows
   - Linux
-  - MacOS
+  - macOS
 contributors: 
   - ATT&CK
   - CTID

--- a/contribution/driver.yml
+++ b/contribution/driver.yml
@@ -4,7 +4,7 @@ collection_layers:
   - host
 platforms:
   - Linux
-  - MacOS
+  - macOS
   - Windows
 contributors: 
   - ATT&CK

--- a/contribution/file.yml
+++ b/contribution/file.yml
@@ -5,7 +5,7 @@ collection_layers:
 platforms:
   - Windows
   - Linux
-  - MacOS
+  - macOS
   - Network
 contributors: 
   - ATT&CK

--- a/contribution/firewall.yml
+++ b/contribution/firewall.yml
@@ -9,7 +9,7 @@ platforms:
   - Office 365
   - Azure AD
   - Linux
-  - MacOS
+  - macOS
   - Windows
 contributors: 
   - ATT&CK

--- a/contribution/firmware.yml
+++ b/contribution/firmware.yml
@@ -5,7 +5,7 @@ collection_layers:
 platforms:
   - Windows
   - Linux
-  - MacOS
+  - macOS
 contributors: 
   - ATT&CK
   - CTID

--- a/contribution/kernel.yml
+++ b/contribution/kernel.yml
@@ -4,7 +4,7 @@ collection_layers:
   - host
 platforms:
   - Linux
-  - MacOS
+  - macOS
 contributors: 
   - ATT&CK
   - CTID

--- a/contribution/logon_session.yml
+++ b/contribution/logon_session.yml
@@ -7,7 +7,7 @@ collection_layers:
 platforms:
   - Windows
   - Linux
-  - MacOS
+  - macOS
   - IaaS
   - SaaS
   - Office 365

--- a/contribution/module.yml
+++ b/contribution/module.yml
@@ -5,7 +5,7 @@ collection_layers:
 platforms:
   - Windows
   - Linux
-  - MacOS
+  - macOS
 contributors: 
   - ATT&CK
   - CTID

--- a/contribution/named_pipe.yml
+++ b/contribution/named_pipe.yml
@@ -5,7 +5,7 @@ collection_layers:
 platforms:
   - Windows
   - Linux
-  - MacOS
+  - macOS
 contributors: 
   - ATT&CK
   - CTID

--- a/contribution/network_share.yml
+++ b/contribution/network_share.yml
@@ -5,7 +5,7 @@ collection_layers:
 platforms:
   - Windows
   - Linux
-  - MacOS
+  - macOS
 contributors: 
   - ATT&CK
   - CTID

--- a/contribution/network_traffic.yml
+++ b/contribution/network_traffic.yml
@@ -7,7 +7,7 @@ collection_layers:
 platforms:
   - Windows
   - Linux
-  - MacOS
+  - macOS
   - IaaS
 contributors: 
   - ATT&CK

--- a/contribution/process.yml
+++ b/contribution/process.yml
@@ -5,7 +5,7 @@ collection_layers:
 platforms:
   - Windows
   - Linux
-  - MacOS
+  - macOS
 contributors: 
   - ATT&CK
   - CTID

--- a/contribution/scheduled_job.yml
+++ b/contribution/scheduled_job.yml
@@ -6,7 +6,7 @@ collection_layers:
 platforms:
   - Windows
   - Linux
-  - MacOS
+  - macOS
   - Containers
 contributors: 
   - ATT&CK

--- a/contribution/sensor_health.yml
+++ b/contribution/sensor_health.yml
@@ -5,7 +5,7 @@ collection_layers:
 platforms:
   - Windows
   - Linux
-  - MacOS
+  - macOS
 contributors: 
   - ATT&CK
   - CTID

--- a/contribution/service.yml
+++ b/contribution/service.yml
@@ -5,7 +5,7 @@ collection_layers:
 platforms:
   - Windows
   - Linux
-  - MacOS
+  - macOS
 contributors: 
   - ATT&CK
   - CTID

--- a/contribution/user_account.yml
+++ b/contribution/user_account.yml
@@ -7,7 +7,7 @@ collection_layers:
 platforms:
   - Windows
   - Linux
-  - MacOS
+  - macOS
   - IaaS
   - SaaS
   - Office 365

--- a/contribution/volume.yml
+++ b/contribution/volume.yml
@@ -7,7 +7,7 @@ platforms:
   - IaaS
   - Windows
   - Linux
-  - MacOS
+  - macOS
 contributors: 
   - ATT&CK
   - CTID

--- a/contribution/web_credential.yml
+++ b/contribution/web_credential.yml
@@ -6,7 +6,7 @@ collection_layers:
 platforms:
   - Windows
   - Linux
-  - MacOS
+  - macOS
   - SaaS
   - Office 365
   - Azure AD


### PR DESCRIPTION
The casing for macOS is not in line with CTI STIX. This was the ok for command.yml but not the other YAML files.