### PR TITLE
Changed references in Command

### DIFF
--- a/contribution/command.yml
+++ b/contribution/command.yml
@@ -28,4 +28,4 @@ references:
   - https://docs.microsoft.com/en-us/sysinternals/downloads/sysmon#event-id-1-process-creation
   - https://confluence.atlassian.com/confkb/how-to-enable-command-line-audit-logging-in-linux-956166545.html
   - https://www.scip.ch/en/?labs.20150108
-  - https://tools.ietf.org/id/draft-ietf-opsawg-tacacs-07.html#rfc.section.7.2
+  - https://tools.ietf.org/id/draft-ietf-opsawg-tacacs-07.html#AuthorizationAttributes

--- a/contribution/command.yml
+++ b/contribution/command.yml
@@ -25,6 +25,7 @@ data_components:
         relationship: executed
         target_data_element: command
 references:
-  - https://docs.microsoft.com/en-us/sysinternals/downloads/sysmon
+  - https://docs.microsoft.com/en-us/sysinternals/downloads/sysmon#event-id-1-process-creation
   - https://confluence.atlassian.com/confkb/how-to-enable-command-line-audit-logging-in-linux-956166545.html
   - https://www.scip.ch/en/?labs.20150108
+  - https://tools.ietf.org/id/draft-ietf-opsawg-tacacs-07.html#rfc.section.7.2

--- a/contribution/command.yml
+++ b/contribution/command.yml
@@ -25,5 +25,6 @@ data_components:
         relationship: executed
         target_data_element: command
 references:
-  - https://tools.ietf.org/id/draft-ietf-opsawg-tacacs-07.html#rfc.section.7.2
-  - https://tools.ietf.org/html/rfc2866
+  - https://docs.microsoft.com/en-us/sysinternals/downloads/sysmon
+  - https://confluence.atlassian.com/confkb/how-to-enable-command-line-audit-logging-in-linux-956166545.html
+  - https://www.scip.ch/en/?labs.20150108


### PR DESCRIPTION
Previous references included rfc for RADIUS and docs for TACACS+, both of which are network authentication/management protocols and have nothing to do with command line monitoring.  I've included references to Sysmon for windows, auditd command-line push to rsyslog for linux, and and instructional blog for auditing with OpenBSM, which is included natively in MacOS since Snow Leopard.