### PR TITLE
Removed deprecated function from attackcti library used in notebook.

### DIFF
--- a/ATT&CK-Data-Sources.ipynb
+++ b/ATT&CK-Data-Sources.ipynb
@@ -7865,7 +7865,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.4"
+   "version": "3.9.5"
   },
   "metadata": {
    "interpreter": {

--- a/docs/scripts/notebook_functions.py
+++ b/docs/scripts/notebook_functions.py
@@ -36,8 +36,6 @@ def get_attck_from_stix(matrix = 'enterprise'):
         lift = attack_client()
         # Getting techniques for windows platform - enterprise matrix
         attck = lift.get_enterprise_techniques(stix_format = False)
-        # Removing revoked techniques
-        attck = lift.remove_revoked(attck)
         return attck
     else:
         sys.exit('ERROR: Only Enterprise available!!')


### PR DESCRIPTION
The notebooks_function.py (https://github.com/mitre-attack/attack-datasources/blob/main/docs/scripts/notebook_functions.py#L11) script in this repo uses the attackcti library (https://github.com/OTRF/ATTACK-Python-Client).

The following function is used in the python script in this repo:

https://github.com/mitre-attack/attack-datasources/blob/main/docs/scripts/notebook_functions.py#L38-L40

The `remove_revoked` reference does not exist in the attackcti library anymore. Therefore, I removed that from the script. Removing deprecated STIX objects is done by default in the attackcti library:

https://github.com/OTRF/ATTACK-Python-Client/blob/master/attackcti/attack_api.py#L364

Issue initially opened in the attackcti GitHub repository: https://github.com/OTRF/ATTACK-Python-Client/issues/53